### PR TITLE
Circular reference fix

### DIFF
--- a/logisim/src/com/cburch/logisim/file/LibraryManager.java
+++ b/logisim/src/com/cburch/logisim/file/LibraryManager.java
@@ -123,10 +123,6 @@ class LibraryManager {
 			return this.fileHandlerId == id;
 		}
 
-		boolean concernsLocalFile(InputStream input) {
-			return this.input == input;
-		}
-
 		String getFileHandlerID() {
 			return this.fileHandlerId;
 		}
@@ -329,6 +325,30 @@ class LibraryManager {
 			}
 		}
 		return null;
+	}
+
+	public String[] findAllLocalReferences(LogisimFile file) {
+		ArrayList<String> matches = new ArrayList();
+		findAllLocalReferencesRecursive(file, matches);
+		String[] s = new String[0];
+		return matches.toArray(s);
+	}
+
+	private void findAllLocalReferencesRecursive(LogisimFile file, ArrayList matches) {
+		for (Library lib : file.getLibraries()) {
+			LibraryDescriptor desc = invMap.get(lib);
+			if (desc instanceof LocalDescriptor) {
+				LocalDescriptor localDesc = (LocalDescriptor) desc;
+				matches.add(localDesc.getFileHandlerID());
+			}
+			if (lib instanceof LoadedLibrary) {
+				LoadedLibrary loadedLib = (LoadedLibrary) lib;
+				if (loadedLib.getBase() instanceof LogisimFile) {
+					LogisimFile nestedFile = (LogisimFile) loadedLib.getBase();
+					findAllLocalReferencesRecursive(nestedFile, matches);
+				}
+			}
+		}
 	}
 	
 	public void fileSaved(Loader loader, File dest, File oldFile, LogisimFile file) {

--- a/logisim/src/com/cburch/logisim/file/LibraryManager.java
+++ b/logisim/src/com/cburch/logisim/file/LibraryManager.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.WeakHashMap;
+import java.util.Set;
+import java.util.LinkedHashSet;
 
 import com.cburch.logisim.tools.Library;
 import com.cburch.logisim.util.StringUtil;
@@ -328,13 +330,13 @@ class LibraryManager {
 	}
 
 	public String[] findAllLocalReferences(LogisimFile file) {
-		ArrayList<String> matches = new ArrayList();
+		Set<String> matches = new LinkedHashSet();
 		findAllLocalReferencesRecursive(file, matches);
 		String[] s = new String[0];
 		return matches.toArray(s);
 	}
 
-	private void findAllLocalReferencesRecursive(LogisimFile file, ArrayList matches) {
+	private void findAllLocalReferencesRecursive(LogisimFile file, Set<String> matches) {
 		for (Library lib : file.getLibraries()) {
 			LibraryDescriptor desc = invMap.get(lib);
 			if (desc instanceof LocalDescriptor) {

--- a/src/javascript/main.js
+++ b/src/javascript/main.js
@@ -36,3 +36,16 @@ window.loadExample = loadExample;
         await cheerpjRunJar("/app/logisim.jar");
 })();
 
+(async function () {
+    const db = await window.idb.openDB("fileHandlersDB", 2, {
+        upgrade(db) {
+            if (!db.objectStoreNames.contains("handlers")) {
+                db.createObjectStore("handlers");
+            }
+            if (!db.objectStoreNames.contains("library")) {
+                db.createObjectStore("library");
+            }
+        }
+    });
+})();
+


### PR DESCRIPTION
Files that reference local libraries can now not be saved onto that file - creating circular references
Local libraries are now also stored in a separate object store, allowing for more seamless loading of files 